### PR TITLE
Chore: a few frontend login changes

### DIFF
--- a/frontend/src/components/nav/Navbar.tsx
+++ b/frontend/src/components/nav/Navbar.tsx
@@ -34,7 +34,7 @@ function Navbar() {
 
       {/* Desktop Login Button */}
       <div className="hidden md:flex flex-1 justify-end items-center h-full">
-        <Link to="/login" className="bg-blue-900 text-l border-black text-white border-black border rounded px-7 py-2 rounded-lg">
+        <Link to="/login" className="hover:bg-main-hover-color bg-main-color text-l text-white border-black border-sm rounded px-7 py-2 rounded-lg">
           Login
         </Link>
       </div>
@@ -77,7 +77,11 @@ function Navbar() {
             >
               Services
             </Link>
-            <Link to="/login" className="block px-3 py-2 bg-blue-900 text-white rounded-md text-center" onClick={() => setIsMenuOpen(false)}>
+            <Link
+              to="/login"
+              className="block px-3 py-2 bg-main-color text-white rounded-md text-center hover:bg-main-hover-color"
+              onClick={() => setIsMenuOpen(false)}
+            >
               Login
             </Link>
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,4 +7,3 @@
 body {
   font-family: 'Inter', sans-serif;
 }
-

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -29,10 +29,11 @@ function Login() {
 
   return (
     <>
-      <div className="mt-40 w-full flex items-center justify-center">
+      <div className="mt-28 w-full flex items-center justify-center">
         <form onSubmit={handleSubmit} className="w-full max-w-md">
           <div className="mb-4">
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+            <h1 className="text-lg text-center mb-6">Welcome back!</h1>
+            <label htmlFor="email" className="block text-sm font-medium mb-2">
               Email
             </label>
             <input
@@ -40,7 +41,7 @@ function Login() {
               id="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-main-color focus:border-main-color"
               placeholder="Enter your email"
             />
           </div>
@@ -53,19 +54,22 @@ function Login() {
               id="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-main-color focus:border-main-color"
               placeholder="Enter your password"
             />
           </div>
           <button
             type="submit"
-            className="mb-10 w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            className="mb-10 w-full bg-main-color text-white py-2 px-4 rounded-md hover:bg-main-hover-color focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
             Login
           </button>
-          <Link to="/signup" className="text-bold text-blue-600 hover:text-blue-700">
-            Register
-          </Link>
+          <div className="justify-center flex">
+            <p>Don't have an account?</p>
+            <Link to="/signup" className="font-bold ml-2 hover:text-main-hover-color text-main-color">
+              Register
+            </Link>
+          </div>
         </form>
       </div>
     </>

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -31,55 +31,75 @@ function Signup() {
 
   return (
     <>
-      <div className="mt-40 w-full flex items-center justify-center">
+      <div className="mt-28 w-full flex items-center justify-center">
         <form onSubmit={handleSubmit} className="w-full max-w-md">
+          <h1 className="text-lg text-center mb-6">Create account!</h1>
           <div className="mb-4">
             <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
               Surname
+              <span className="text-red-600"> *</span>
             </label>
             <input
               type="text"
               id="name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-main-color focus:border-main-color"
               placeholder="Enter your surname"
             />
           </div>
           <div className="mb-4">
             <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
               Email
+              <span className="text-red-600"> *</span>
             </label>
             <input
               type="email"
               id="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-main-color focus:border-main-color"
               placeholder="Enter your email"
             />
           </div>
           <div className="mb-6">
             <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
               Password
+              <span className="text-red-600"> *</span>
             </label>
             <input
               type="password"
               id="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-main-color focus:border-main-color"
               placeholder="Enter your password"
+            />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="repassword" className="block text-sm font-medium text-gray-700 mb-2">
+              Confirm Password
+              <span className="text-red-600"> *</span>
+            </label>
+            <input
+              type="password"
+              id="repassword"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-main-color focus:border-main-color"
+              placeholder="Confirm password"
             />
           </div>
           <button
             type="submit"
-            className="mb-10 w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            className="mb-10 w-full bg-main-color text-white py-2 px-4 rounded-md hover:bg-main-hover-color focus:outline-none focus:ring-2 focus:ring-offset-2"
           >
             Register
           </button>
-          <Link to="/login" className="text-bold text-blue-600 hover:text-blue-700">Login</Link>
-
+          <div className="justify-center flex">
+            <p>Already have an account?</p>
+            <Link to="/login" className="hover:text-hover-color ml-2 font-bold text-main-color hover:text-main-hover-color">
+              Login
+            </Link>
+          </div>
         </form>
       </div>
     </>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,7 +4,12 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}", 
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        "main-color": "#1767e8ff",
+        "main-hover-color": "#0f4ecaff"
+      }
+    },
   },
-plugins: [],
-};
+  plugins: [],
+}


### PR DESCRIPTION
## PR Checklist

- [x] Code passes Github workflow
- [x] Code runs npm run test succesfully on the backend (test manually)
- [x] No merge conflicts

## Changes
- * for fields that are not optional in signup
- Made a main color field in tailwind config. This means that when coloring something with the main color use either bg-main-color or text-main-color this will make it easy in the future when just wanting to change the main color.
- Added a confirm password field (has no implementation)
- "Welcome back!" header and a small text below for both login and sign up like "Don't have an account?"

For the tailwind config it is important this is the way we do it... Adding a color there like the primary color, secondary etc, and then use the colors throughout. It is scalable this way :)

## Pictures
<img width="613" height="605" alt="image" src="https://github.com/user-attachments/assets/cd283d01-1026-4218-b212-49fe6a971be3" />
